### PR TITLE
fix: Remove blocking call and deprecated API

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -87,8 +87,7 @@ The framework automatically handles location permission requests and provides cl
 
 The framework provides detailed error cases through `GPSLocationError`:
 
-- `authorizationDenied`: User denied location access for the app
-- `authorizationDeniedGlobally`: Location services are disabled system-wide
+- `authorizationDenied`: Location access is not available (app denied or system-wide disabled)
 - `authorizationRestricted`: Location access is restricted by parental controls
 - `insufficientlyInUse`: Current authorization level is insufficient
 - `notFound`: Unable to determine location
@@ -105,9 +104,6 @@ do {
 } catch GPSLocationError.authorizationDenied {
     // Guide user to Settings > Privacy & Security > Location Services
     showLocationPermissionAlert()
-} catch GPSLocationError.authorizationDeniedGlobally {
-    // Guide user to enable Location Services system-wide
-    showSystemLocationServicesAlert()
 } catch GPSLocationError.locationUnavailable {
     // Handle airplane mode, poor GPS signal, etc.
     showLocationUnavailableAlert()

--- a/Sources/LocationProvider/LocationProvider.docc/BestPractices.md
+++ b/Sources/LocationProvider/LocationProvider.docc/BestPractices.md
@@ -573,8 +573,6 @@ extension GPSLocationError {
         switch self {
         case .authorizationDenied:
             return "Enable location access in Settings."
-        case .authorizationDeniedGlobally:
-            return "Turn on Location Services in Settings."
         case .locationUnavailable, .notFound:
             return "Make sure you have GPS signal and try again."
         default:

--- a/Sources/LocationProvider/LocationProvider.swift
+++ b/Sources/LocationProvider/LocationProvider.swift
@@ -260,13 +260,3 @@ private extension LocationProvider.AccuracyRequirement {
         }
     }
 }
-
-extension CLPlacemark {
-    /// Returns the locality (city) name from the placemark if available.
-    ///
-    /// - Returns: A string containing the locality name, or nil if not available
-    var placemarkName: String? {
-        guard let locality else { return nil }
-        return "\(locality)"
-    }
-}

--- a/Sources/LocationProvider/LocationProviderClient.swift
+++ b/Sources/LocationProvider/LocationProviderClient.swift
@@ -28,7 +28,7 @@ extension LocationProvider {
         ///
         /// - Throws: The stream may throw the following errors:
         ///   - `CLError`: Core Location errors including:
-        ///     - `.denied`: User denied location permissions (mapped to `GPSLocationError.authorizationDenied` or `.authorizationDeniedGlobally`)
+        ///     - `.denied`: User denied location permissions (mapped to `GPSLocationError.authorizationDenied`)
         ///     - `.locationUnknown`: Unable to determine location (mapped to `GPSLocationError.locationUnavailable`)
         ///     - `.network`: Network-related failure (mapped to `GPSLocationError.locationUnavailable`)
         ///   - `CancellationError`: When the stream is cancelled (filtered out, not surfaced to users)

--- a/Technical.md
+++ b/Technical.md
@@ -48,7 +48,6 @@ classDiagram
         +authorizationRestricted
         +notFound
         +authorizationDenied
-        +authorizationDeniedGlobally
         +insufficientlyInUse
         +locationUnavailable
         +serviceSessionRequired
@@ -141,7 +140,6 @@ flowchart TD
     A[Start Location Request] --> B{Check Authorization}
     B -->|Restricted| C[Throw authorizationRestricted]
     B -->|Denied| D[Throw authorizationDenied]
-    B -->|Denied Globally| E[Throw authorizationDeniedGlobally]
     B -->|Insufficient| F[Throw insufficientlyInUse]
     B -->|Authorized| G{Start Updates}
     

--- a/Tests/LocationProviderTests/LocationProviderTests.swift
+++ b/Tests/LocationProviderTests/LocationProviderTests.swift
@@ -281,15 +281,15 @@ struct LocationProviderTest {
             }
         }
 
-        @Test("Location services denied globally, Error thrown")
+        @Test("Location services denied globally maps to authorizationDenied")
         func globallyDenied() async throws {
-            let locationUpdate = MockLocationUpdate.deniedGlobally()
+            let locationUpdate = MockLocationUpdate(authorizationDeniedGlobally: true, locationUnavailable: true)
             let client = LocationProvider.Client.test(
                 updates: [locationUpdate],
                 reverseGeocodeLocation: .success("KraigTown"))
             let locationProvider = LocationProvider(client: client)
 
-            await #expect(throws: GPSLocationError.authorizationDeniedGlobally) {
+            await #expect(throws: GPSLocationError.authorizationDenied) {
                 _ = try await locationProvider.gpsLocation()
             }
         }

--- a/Tests/LocationProviderTests/MockLocationUpdate.swift
+++ b/Tests/LocationProviderTests/MockLocationUpdate.swift
@@ -125,13 +125,6 @@ extension MockLocationUpdate {
             locationUnavailable: true)
     }
 
-    /// Creates a mock representing a globally denied authorization state.
-    static func deniedGlobally() -> Self {
-        Self(
-            authorizationDeniedGlobally: true,
-            locationUnavailable: true)
-    }
-
     /// Creates a mock representing a restricted authorization state.
     static func restricted() -> Self {
         Self(


### PR DESCRIPTION
## Summary

- **Remove `authorizationDeniedGlobally` error case** - The distinction between app-level and system-wide location denial required calling `CLLocationManager.locationServicesEnabled()`, which is a blocking call that can cause UI hangs. Both cases now map to `.authorizationDenied` since the Settings UI clearly shows users whether location is disabled system-wide or just for the app.

- **Replace deprecated `CLGeocoder` with `MKReverseGeocodingRequest`** - Updated to modern MapKit API for reverse geocoding, removing the deprecated CoreLocation geocoder.

## Test plan

- [x] All 17 unit tests pass
- [x] Verified `authorizationDeniedGlobally` flag still correctly maps to `authorizationDenied`
- [x] Documentation updated to reflect simplified error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)