### PR TITLE
fix: Replace polling timeout with structured concurrency race

### DIFF
--- a/Sources/LocationProvider/GPSLocationError.swift
+++ b/Sources/LocationProvider/GPSLocationError.swift
@@ -13,7 +13,7 @@ import Foundation
 /// This enum abstracts Core Location's complex error model into actionable GPS-specific errors.
 /// Each case maps to specific user guidance in errorDescription, enabling apps to show
 /// contextual help without reimplementing Core Location error logic everywhere.
-public enum GPSLocationError: LocalizedError {
+public enum GPSLocationError: LocalizedError, Sendable {
     /// Location access is restricted by parental controls or device management
     ///
     /// Why this exists: Users with managed devices (MDM, Screen Time) may have location


### PR DESCRIPTION
## Summary
- Refactors location acquisition to use `withTaskGroup` for timeout handling instead of checking elapsed time on each location update
- Adds `AcquisitionState` actor to isolate mutable timing state and eliminate data races
- Adds `Sendable` conformance to `GPSLocationError` for Swift 6 data-race safety
- Fixes test race condition by using 200ms timeout instead of 0

## Why
The previous implementation coupled timeout checks to location update frequency, creating a potential race condition. The new structured concurrency approach uses a dedicated timeout task that sleeps until the deadline, making the timeout behavior deterministic and independent of update frequency.

## Test plan
- [x] All 18 existing unit tests pass
- [x] New test added for stream stall timeout scenario
- [x] Periphery scan shows no dead code
- [x] SwiftFormat applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)